### PR TITLE
Fix typo in constants.py for UCLALES constants

### DIFF
--- a/pyclouds/reference/constants.py
+++ b/pyclouds/reference/constants.py
@@ -83,7 +83,7 @@ ATHAM_constants = {
 
 UCLALES_constants = {
     "cp_d": 1005.0,
-    "R_d": 187.04,
+    "R_d": 287.04,
     "L_v": 2500000.0,
     "cp_l": 4183.0,
     "cp_i": 2103.0,


### PR DESCRIPTION
Gas constant for dry air had a typo, see https://github.com/uclales/uclales/blob/master/src/defs.f90#L25 for true value