### PR TITLE
Update parcel.py

### DIFF
--- a/pyclouds/models/parcel.py
+++ b/pyclouds/models/parcel.py
@@ -626,6 +626,9 @@ class FullThermodynamicsCloudEquations(CloudModel):
         rho_c = self.cloud_mixture_density(
             p=p, T_c=T, qd_c=q_d, qv_c=q_v, ql_c=q_l, qi_c=q_i, qr_c=q_r
         )
+        # some of the rho_c values produced here are nan or even negative in a few cases. 
+        # found this by adding a print statement for rho_c here and then running the model (in the moist integration notebook for example). 
+        
         g = self.constants.g
         B = (rho_e - rho_c) / rho_e
         mu = self._mu(r=r, w=w, B=B, z=z)


### PR DESCRIPTION
Was playing around with the entrainment term to test for a different kind of parameterisation which requires the value for buoyancy in its calculation. I calculated buoyancy as: -g*(cloud density - environment density). This brought me to rho_c which, when generally has expected behaviour, but at some rare points has odd anomalies. Here is a section of the values: 
...
1.116959183193716
1.1039598870454252
1.097113145319669
0.7909797510557045
-0.00012469050121002718
nan
nan
1.114346875346376
1.1130510056341305
1.1065541081288586
...

Do you have any idea why this happens?